### PR TITLE
Add count_of_pension_pots field to DB

### DIFF
--- a/db/migrate/20160718131146_add_count_of_pension_pots.rb
+++ b/db/migrate/20160718131146_add_count_of_pension_pots.rb
@@ -1,0 +1,5 @@
+class AddCountOfPensionPots < ActiveRecord::Migration
+  def change
+    add_column :appointment_summaries, :count_of_pension_pots, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160712095513) do
+ActiveRecord::Schema.define(version: 20160718131146) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,6 +53,7 @@ ActiveRecord::Schema.define(version: 20160712095513) do
     t.boolean  "plans_for_poor_health"
     t.string   "reference_number"
     t.integer  "number_of_previous_appointments",                  default: 0,                null: false
+    t.integer  "count_of_pension_pots"
   end
 
   add_index "appointment_summaries", ["user_id"], name: "index_appointment_summaries_on_user_id", using: :btree


### PR DESCRIPTION
Data migration required be #19 

This had the count_of_pension_pots field to allow collection of data inline with the Appendix C agreement.
