### PR TITLE
Updating app to use latest version of puma

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,7 +209,7 @@ GEM
       slop (~> 3.4)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
-    puma (2.15.3)
+    puma (3.8.2)
     rack (2.0.2)
     rack-test (0.6.3)
       rack (>= 1.0)


### PR DESCRIPTION
Running a bundle install of the app caused an issue
for me when it was trying to install the puma gem.

Updating to use the latest version of puma seemed
to fix this.